### PR TITLE
Fix for Laravel 5.4

### DIFF
--- a/src/Jameswmcnab/ConfigYaml/ConfigYamlServiceProvider.php
+++ b/src/Jameswmcnab/ConfigYaml/ConfigYamlServiceProvider.php
@@ -38,7 +38,7 @@ class ConfigYamlServiceProvider extends ServiceProvider {
         $this->registerDefaultRepository();
 
         // Register facade accessor
-        $this->app['config-yaml'] = $this->app->share(function(Application $app)
+        $this->app->singleton('config-yaml', function(Application $app)
         {
             return $app->make('Jameswmcnab\ConfigYaml\RepositoryInterface');
         });


### PR DESCRIPTION
Laravel 5.4 removed the `share` method from the application container: `singleton` should be used instead. 

This is backwards compatible because the `singleton` method exists in previous Laravel 5.x versions.