### PR TITLE
Fix bugs and add package discovery

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{php,stub,json}]
+indent_size = 4
+
+[*.{md,yml}]
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,6 @@ before_script:
   - travis_retry composer self-update
   - travis_retry composer install --prefer-source --no-interaction --dev
 
-script: vendor/bin/phpspec run
+script:
+  - vendor/bin/phpspec run
+  - vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -13,32 +13,19 @@ By default the package assumes your YAML files are in the `base_path()` director
 this by publishing the package config file (`config-yaml.php`) to your application and changing the `yaml_path` key.
 
 ## Installation
-Require this package in your `composer.json` file:
 
-``` json
-"jameswmcnab/config-yaml": "^2.0",
-```
+Installation is via Composer:
 
-Then add the package service provider your `providers` array in your `app.php`:
-
-``` php
-Jameswmcnab\ConfigYaml\ConfigYamlServiceProvider::class,
-````
-
-#### Register facade alias (optional)
-
-If you wish to use the `ConfigYaml` facade then register the alias in the `aliases` array in your `app.php`:
-
-``` php
-'ConfigYaml' => Jameswmcnab\ConfigYaml\Facades\ConfigYaml::class,
+```bash
+$ composer require jameswmcnab/config-yaml
 ```
 
 #### Publish package config (optional)
 
 If you want to customise the package config, publish the package config then edit the newly created `config/config-yaml.php` file:
 
-``` bash
-php artisan vendor:publish --provider=ConfigYamlServiceProvider
+```bash
+$ php artisan vendor:publish --provider=ConfigYamlServiceProvider
 ```
 
 ## Usage
@@ -111,8 +98,9 @@ class FooBar
 
 ## Running Tests
 
-This package has a few unit tests (although no as many as I would like). Run this via phpspec:
+To run the package tests:
 
 ``` bash
-vendor/bin/phpspec run
+$ vendor/bin/phpspec run
+$ vendor/bin/phpunit
 ```

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,11 @@
             "Jameswmcnab\\ConfigYaml\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Jameswmcnab\\ConfigYaml\\Tests\\": "tests/"
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-develop": "3.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,14 @@
     "extra": {
         "branch-alias": {
             "dev-develop": "3.x-dev"
+        },
+        "laravel": {
+            "providers": [
+                "\\Jameswmcnab\\ConfigYaml\\ConfigYamlServiceProvider"
+            ],
+            "aliases": {
+                "ConfigYaml": "\\Jameswmcnab\\ConfigYaml\\Facades\\ConfigYaml"
+            }
         }
     },
     "suggest": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         syntaxCheck="true"
+         verbose="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit/</directory>
+        </testsuite>
+        <testsuite name="Integration">
+            <directory suffix="Test.php">./tests/Integration/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/CachingRepository.php
+++ b/src/CachingRepository.php
@@ -71,8 +71,8 @@ class CachingRepository implements RepositoryInterface
      */
     public function get($key, $default = null)
     {
-        return $this->cache->remember($key, $this->cacheAgeMinutes, function (Repository $repository) use ($key, $default) {
-           return $repository->get($key, $default);
+        return $this->cache->remember($key, $this->cacheAgeMinutes, function () use ($key, $default) {
+           return $this->repository->get($key, $default);
         });
     }
 

--- a/src/ConfigYamlServiceProvider.php
+++ b/src/ConfigYamlServiceProvider.php
@@ -17,7 +17,7 @@ class ConfigYamlServiceProvider extends ServiceProvider
     {
         // Merge default configuration
         $this->mergeConfigFrom(
-            __DIR__.'../config/config-yaml.php', 'config-yaml'
+            __DIR__ . '/../config/config-yaml.php', 'config-yaml'
         );
 
         // Register default Loader
@@ -27,9 +27,7 @@ class ConfigYamlServiceProvider extends ServiceProvider
         $this->registerDefaultRepository();
 
         // Register facade accessor
-        $this->app->singleton('config-yaml', function (Application $app) {
-            return $app->make(RepositoryInterface::class);
-        });
+        $this->app->alias(RepositoryInterface::class, 'config-yaml');
     }
 
     /**

--- a/tests/Integration/ConfigYamlTest.php
+++ b/tests/Integration/ConfigYamlTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jameswmcnab\ConfigYaml\Tests\Integration;
+
+use Jameswmcnab\ConfigYaml\CachingRepository;
+use Jameswmcnab\ConfigYaml\Facades\ConfigYaml;
+use Jameswmcnab\ConfigYaml\Repository;
+use Jameswmcnab\ConfigYaml\RepositoryInterface;
+use Illuminate\Contracts\Cache\Repository as Cache;
+
+class ConfigYamlTest extends TestCase
+{
+
+    public function testDefaultRepository()
+    {
+        $expected = [
+            'foo' => ['bar' => 'foobar'],
+            'baz' => ['bat' => 'bazbat'],
+        ];
+
+        $this->assertEquals($expected, ConfigYaml::get('test'));
+        $this->assertEquals($expected['foo']['bar'], ConfigYaml::get('test.foo.bar'));
+    }
+
+    public function testCachingRepository()
+    {
+        $this->app->singleton(RepositoryInterface::class, function () {
+            return new CachingRepository(
+                $this->app->make(Repository::class),
+                $this->app->make(Cache::class)
+            );
+        });
+
+        $this->assertInstanceOf(CachingRepository::class, $this->app->make('config-yaml'));
+        $this->assertEquals('bazbat', ConfigYaml::get('test.baz.bat'));
+    }
+}

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Jameswmcnab\ConfigYaml\Tests\Integration;
+
+use Illuminate\Foundation\Application;
+use Jameswmcnab\ConfigYaml\ConfigYamlServiceProvider;
+use Jameswmcnab\ConfigYaml\Facades\ConfigYaml;
+use Orchestra\Testbench\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+
+    /**
+     * @return void
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        config()->set('config-yaml.yaml_path', __DIR__ . '/../fixtures');
+    }
+
+    /**
+     * @param Application $app
+     * @return array
+     */
+    protected function getPackageProviders($app)
+    {
+        return [
+            ConfigYamlServiceProvider::class,
+        ];
+    }
+
+    /**
+     * @param Application $app
+     * @return array
+     */
+    protected function getPackageAliases($app)
+    {
+        return [
+            'ConfigYaml' => ConfigYaml::class,
+        ];
+    }
+}

--- a/tests/fixtures/test.yaml
+++ b/tests/fixtures/test.yaml
@@ -1,0 +1,5 @@
+foo:
+  bar: "foobar"
+
+baz:
+  bat: "bazbat"


### PR DESCRIPTION
Bugs were:

1. Merging config has an invalid path (not sure why this hasn't caused an error in previous versions).
2. Caching repository had an invalid closure when calling the cache's `remember` method.